### PR TITLE
cout replaced with SDL_LogMessage

### DIFF
--- a/blue-tiles-engine/engine/debugbt/DebugLog.cpp
+++ b/blue-tiles-engine/engine/debugbt/DebugLog.cpp
@@ -1,16 +1,73 @@
 #include "DebugLog.h"
-#include <iostream>
-
+#include <time.h>
+#include <sdl2/SDL_rwops.h>
+#include <sstream>
 
 namespace DebugLog
 {
+
+	/*
+	* Taken from SDL_test_log.c
+	*/
+	static char* TimestampToString(const time_t timestamp)
+	{
+		time_t copy;
+		static char buffer[64];
+		struct tm local;
+		SDL_memset(buffer, 0, sizeof(buffer));
+		copy = timestamp;
+		localtime_s(&local, &copy);
+		strftime(buffer, sizeof(buffer), "%x %X", &local);
+
+		return buffer;
+	}
+
+	static string TimestampedString(string msg)
+	{
+		std::stringstream ss;
+		ss << TimestampToString(time(0)) << ": " << msg.c_str();
+		return ss.str();
+	}
+
 	void Info(string infoMsg)
 	{
-		cout << infoMsg << endl;
+		Info(SDL_LOG_CATEGORY_TEST, infoMsg);
+	}
+
+	void Info(int category, string infoMsg)
+	{
+		SDL_LogMessage(category, SDL_LOG_PRIORITY_INFO, TimestampedString(infoMsg).c_str());
+	}
+
+	void Warn(string warnMsg)
+	{
+		Warn(SDL_LOG_CATEGORY_TEST, warnMsg);
+	}
+
+	void Warn(int category, string warnMsg)
+	{
+		SDL_LogMessage(category, SDL_LOG_PRIORITY_WARN, TimestampedString(warnMsg).c_str());
 	}
 
 	void Error(string errorMsg)
 	{
-		cerr << errorMsg << endl;
+		Error(SDL_LOG_CATEGORY_TEST, errorMsg);
+	}
+
+	void Error(int category, string errorMsg)
+	{
+		std::string timedMsg = TimestampedString(errorMsg);
+
+		SDL_RWops* rw = SDL_RWFromFile("error.log", "w");
+		if (rw != NULL)
+		{
+			size_t len = SDL_strlen(timedMsg.c_str());
+			if (SDL_RWwrite(rw, timedMsg.c_str(), 1, len) != len)
+			{
+				Warn("Couldn't write message to log file.");
+			}
+			SDL_RWclose(rw);
+		}
+		SDL_LogMessage(category, SDL_LOG_PRIORITY_ERROR, timedMsg.c_str());
 	}
 }

--- a/blue-tiles-engine/engine/debugbt/DebugLog.h
+++ b/blue-tiles-engine/engine/debugbt/DebugLog.h
@@ -2,14 +2,27 @@
 
 #include <stdio.h>
 #include <string>
+#include <sdl2/SDL_log.h>
 
 using namespace std;
 
 namespace DebugLog
 {
+// Taken from SDL_test_log.h
+static char* TimestampToString(const time_t timestamp);
+
+static string TimestampedString(string msg);
 
 void Info(string infoMsg);
 
+void Info(int category, string infoMsg);
+
+void Warn(string warnMsg);
+
+void Warn(int category, string warnMsg);
+
 void Error(string errorMsg);
+
+void Error(int category, string errorMsg);
 
 };


### PR DESCRIPTION
SDL_LogMessage instead of cout, logs to file.

Replaced instances of cout with SDL_LogMessage, priority based on the log priority. (Info, Warn, Error). The Error function will also log the message to the error.log file.

Still needs to get a trace to the calling function, line, file.

Resolves:
http://btechgames.bcit.ca/redmine/issues/7191